### PR TITLE
FIX: Remove memory limits to allow large synthetic datasets

### DIFF
--- a/guidellm/openshift/job.yaml
+++ b/guidellm/openshift/job.yaml
@@ -32,11 +32,6 @@ spec:
           value: "/results/results.json"
         - name: GUIDELLM_PROCESSOR
           value: "/mnt/tokenizer"
-        resources:
-          requests:
-            memory: "8Gi"
-          limits:
-            memory: "8Gi"
         volumeMounts:
         - name: results
           mountPath: /results


### PR DESCRIPTION
The limit of 8GB is too low for large synthetic datasets. Removing this limit to not indicate any pre-defined limits